### PR TITLE
Remove trailing slash from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ A _dead simple_ script that installs (build) dependencies, clones [Supercollider
 ## How to?
 
 ```bash
-$ git clone https://github.com/lvm/build-supercollider/
+$ git clone https://github.com/lvm/build-supercollider
 $ cd build-supercollider
 $ sh build-supercollider.sh
 $ sh build-sc3-plugins.sh


### PR DESCRIPTION
Cut & paste won't work with the slash in there.