### PR TITLE
Install qt-default in a separate process to deal with #19

### DIFF
--- a/build-sc3-plugins.sh
+++ b/build-sc3-plugins.sh
@@ -26,8 +26,9 @@ sudo apt install -yq \
          libjack-jackd2-dev libudev-dev libsndfile1-dev libasound2-dev \
          libavahi-client-dev libicu-dev libreadline6-dev libfftw3-dev \
          libxt-dev libcwiid-dev libqt5webkit5-dev libqt5sensors5-dev \
-         qt5-default qt5-qmake qttools5-dev qttools5-dev-tools \
+         qt5-qmake qttools5-dev qttools5-dev-tools \
          qtdeclarative5-dev qtpositioning5-dev
+sudo apt install -yq qt5-default
 
 ###
 #

--- a/build-supercollider.sh
+++ b/build-supercollider.sh
@@ -24,9 +24,10 @@ sudo apt install -yq \
          libjack-jackd2-dev libudev-dev libsndfile1-dev libasound2-dev \
          libavahi-client-dev libicu-dev libreadline6-dev libfftw3-dev \
          libxt-dev libcwiid-dev libqt5webkit5-dev libqt5sensors5-dev \
-         qt5-default qt5-qmake qttools5-dev qttools5-dev-tools \
+         qt5-qmake qttools5-dev qttools5-dev-tools \
          qtdeclarative5-dev qtpositioning5-dev libqt5opengl5-dev \
          qtwebengine5-dev libqt5svg5-dev libqt5websockets5-dev emacs
+sudo apt install -yq qt5-default
 
 ###
 #


### PR DESCRIPTION
With this fix, apt won't fail completely in distros without the
qt5-default package, and other dependencies get to be installed.