### PR TITLE
Removed reference to outdated SC3 plugin branch

### DIFF
--- a/build-sc3-plugins.sh
+++ b/build-sc3-plugins.sh
@@ -5,7 +5,7 @@
 # Variables
 #
 INSTALL_DIR=/tmp
-SUPERCOLLIDER_VER=3.10
+SUPERCOLLIDER_VER=3.11
 SC3PLUGINS_DIR=$INSTALL_DIR/sc3-plugins
 SC3PLUGINS_BUILD_DIR=$SC3PLUGINS_DIR/build
 SC3_DIRECTORY=/usr/local/share/SuperCollider
@@ -37,7 +37,7 @@ sudo apt install -yq qt5-default
 mkdir -p $SC3PLUGINS_DIR
 
 # Download SC3 Plugins Source
-git clone --recursive --branch $SUPERCOLLIDER_VER \
+git clone --recursive \
     https://github.com/supercollider/sc3-plugins.git $SC3PLUGINS_DIR
 
 # Create the the directory where SC3 Plugins will be built

--- a/build-sc3-plugins.sh
+++ b/build-sc3-plugins.sh
@@ -37,7 +37,7 @@ sudo apt install -yq qt5-default
 mkdir -p $SC3PLUGINS_DIR
 
 # Download SC3 Plugins Source
-git clone --recursive \
+git clone --recursive --branch $SUPERCOLLIDER_VER \
     https://github.com/supercollider/sc3-plugins.git $SC3PLUGINS_DIR
 
 # Create the the directory where SC3 Plugins will be built


### PR DESCRIPTION
The 3.10 branch of the SC3 plugins repository contained an error in one of the plugins, that had been corrected in the master branch. When running the build-sc3-plugins script, it repeatedly failed due to the error. I removed the code that cloned the 3.10 branch.